### PR TITLE
find-symlinks: update to 1.0.1

### DIFF
--- a/Formula/find-symlinks.rb
+++ b/Formula/find-symlinks.rb
@@ -1,8 +1,8 @@
 class FindSymlinks < Formula
   desc "Fast symlink finder"
   homepage "https://github.com/rhukster/find-symlinks"
-  url "https://github.com/rhukster/find-symlinks/archive/refs/tags/1.0.0.tar.gz"
-  sha256 "794a1eb452a9ede1d47fd252ff80b7469eae3153b2ec07cb9a02e26f17764c05"
+  url "https://github.com/rhukster/find-symlinks/archive/refs/tags/1.0.1.tar.gz"
+  sha256 "a3598050b277672c02d9f51997e5126213290183c0b395381cc56146080af85e"
   head "https://github.com/rhukster/find-symlinks.git", branch: "main"
 
   depends_on "rust" => :build


### PR DESCRIPTION
Update Formula/find-symlinks.rb to:
- url: https://github.com/rhukster/find-symlinks/archive/refs/tags/1.0.1.tar.gz
- sha256: a3598050b277672c02d9f51997e5126213290183c0b395381cc56146080af85e
Triggered by release 1.0.1.